### PR TITLE
FEAT: 로그인 및 회원가입 구현 #1

### DIFF
--- a/src/main/java/com/team2/levelog/config/WebSecurityConfig.java
+++ b/src/main/java/com/team2/levelog/config/WebSecurityConfig.java
@@ -19,6 +19,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import javax.servlet.http.HttpSession;
+
 // 1. 기능   : Spring Security 설정
 // 2. 작성자 : 서혁수
 @Configuration
@@ -63,6 +65,17 @@ public class WebSecurityConfig {
                 .and()
                 .addFilterBefore(new JwtAuthFilter(jwtUtil),
                         UsernamePasswordAuthenticationFilter.class);
+
+        http.logout()
+                .logoutUrl("/api/auth/logout")
+                .logoutSuccessUrl("/")
+                .deleteCookies("JSESSIONID", "remember-me")
+                .logoutSuccessHandler((request, response, authentication) -> response.sendRedirect("/"))
+                .addLogoutHandler((request, response, authentication) -> {
+                    System.out.println("로그아웃 완료");
+                    HttpSession session = request.getSession();
+                    session.invalidate();
+                });
 
         return http.build();
     }

--- a/src/main/java/com/team2/levelog/global/TestDto.java
+++ b/src/main/java/com/team2/levelog/global/TestDto.java
@@ -1,0 +1,14 @@
+package com.team2.levelog.global;
+
+import lombok.Getter;
+
+@Getter
+public class TestDto {
+    private int status;
+    private String msg;
+
+    public TestDto(int status, String msg) {
+        this.status = status;
+        this.msg = msg;
+    }
+}

--- a/src/main/java/com/team2/levelog/user/controller/UserController.java
+++ b/src/main/java/com/team2/levelog/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.team2.levelog.user.controller;
 
-import com.team2.levelog.user.dto.LoginRequestDto;
+import com.team2.levelog.user.dto.DupRequestCheck;
+import com.team2.levelog.user.dto.SigninRequestDto;
 import com.team2.levelog.user.dto.SignUpRequestDto;
 import com.team2.levelog.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -25,9 +26,19 @@ public class UserController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequestDto loginRequestDto, HttpServletResponse response) {
-        userService.login(loginRequestDto, response);
+    public ResponseEntity<?> login(@RequestBody SigninRequestDto signinRequestDto, HttpServletResponse response) {
+        userService.login(signinRequestDto, response);
         return null;
+    }
+
+    @PostMapping("/dupemail")
+    public ResponseEntity<?> dupEmailCheck(@RequestBody DupRequestCheck requestCheck) {
+        return userService.dupCheckEmail(requestCheck);
+    }
+
+    @PostMapping("/dupnick")
+    public ResponseEntity<?> dupNickCheck(@RequestBody DupRequestCheck requestCheck) {
+        return userService.dupCheckNick(requestCheck);
     }
 
 }

--- a/src/main/java/com/team2/levelog/user/dto/DupRequestCheck.java
+++ b/src/main/java/com/team2/levelog/user/dto/DupRequestCheck.java
@@ -1,0 +1,9 @@
+package com.team2.levelog.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class DupRequestCheck {
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/team2/levelog/user/dto/SignUpRequestDto.java
+++ b/src/main/java/com/team2/levelog/user/dto/SignUpRequestDto.java
@@ -20,8 +20,8 @@ public class SignUpRequestDto {
     private String password;
 
     // 닉네임 정규식 검사
-    @Pattern(regexp = "[a-zA-Z0-9ㄱ-ㅎ가-힣]{2,12}",
-            message = "최소 4 자 최대 12 자, 영어 대소문자, 숫자, 한글 만 사용")
+    @Pattern(regexp = "[a-zA-Z0-9가-힣]{2,12}",
+            message = "최소 2 자 최대 12 자, 영어 대소문자, 숫자, 한글 만 사용")
     private String nickname;
 
     // 프로필 이미지 default 로 들어가는 이미지도 존재한다.

--- a/src/main/java/com/team2/levelog/user/dto/SigninRequestDto.java
+++ b/src/main/java/com/team2/levelog/user/dto/SigninRequestDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 // 1. 기능    : 로그인 시 입력 요소
 // 2. 작성자  : 조소영
 @Getter
-public class LoginRequestDto {
+public class SigninRequestDto {
     private String email;       // 유저 이메일
     private String password;    // 유저 비밀번호
 }

--- a/src/main/java/com/team2/levelog/user/service/UserService.java
+++ b/src/main/java/com/team2/levelog/user/service/UserService.java
@@ -1,12 +1,15 @@
 package com.team2.levelog.user.service;
 
+import com.team2.levelog.global.TestDto;
 import com.team2.levelog.global.jwt.JwtUtil;
-import com.team2.levelog.user.dto.LoginRequestDto;
+import com.team2.levelog.user.dto.DupRequestCheck;
+import com.team2.levelog.user.dto.SigninRequestDto;
 import com.team2.levelog.user.dto.SignUpRequestDto;
 import com.team2.levelog.user.entity.User;
 import com.team2.levelog.user.entity.UserRoleEnum;
 import com.team2.levelog.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -39,7 +42,7 @@ public class UserService {
     }
 
     // 폼 로그인
-    public void login(LoginRequestDto requestDto, HttpServletResponse response) {
+    public void login(SigninRequestDto requestDto, HttpServletResponse response) {
         String email = requestDto.getEmail();
         String password = requestDto.getPassword();
 
@@ -52,6 +55,22 @@ public class UserService {
         }
 
         response.addHeader(JwtUtil.AUTHORIZATION_HEADER, jwtUtil.createToken(user.getEmail(), user.getNickname(), UserRoleEnum.USER.getAuthority()));
+    }
+
+    public ResponseEntity<TestDto> dupCheckEmail(DupRequestCheck requestCheck) {
+        if (userRepository.existsByEmail(requestCheck.getEmail())) {
+            return ResponseEntity.badRequest().body(new TestDto(400, "중복 이메일 존재"));
+        } else {
+            return ResponseEntity.ok().body(new TestDto(200, "사용 가능한 이메일 입니다."));
+        }
+    }
+
+    public ResponseEntity<TestDto> dupCheckNick(DupRequestCheck requestCheck) {
+        if (userRepository.existsByNickname(requestCheck.getNickname())) {
+            return ResponseEntity.badRequest().body(new TestDto(400, "중복 닉네임 존재"));
+        } else {
+            return ResponseEntity.ok().body(new TestDto(200, "사용 가능한 닉네임 입니다."));
+        }
     }
 
     // 회원탈퇴


### PR DESCRIPTION
- 중복 이메일, 닉네임 체크 API 추가 프론트에서 회원가입 view 에 중복체크 버튼이 추가되어서 새롭게 두가지 API 와 테스트용 DTO 를 추가했습니다.
- 회원가입 정규표현식 수정 닉네임 정규식에 잘못된 부분이 있어 수정 및 메시지도 수정했습니다.